### PR TITLE
Show storage usage at the top of the page

### DIFF
--- a/controllers/UserController.ts
+++ b/controllers/UserController.ts
@@ -131,8 +131,13 @@ userController.get('/files', (req, res) => {
 
         File.find({userId: {$eq: req.cookies.auth}}, 'fileName dateCreated fileSize').lean().then(files => {
             if (files.length === 0) return HTTP.SendHTTP(req, res, 200, {files: []})
+
+            let storageBytesUsed = 0;
+            for (let i = 0; i < files.length; i++) {
+                storageBytesUsed += files[i].fileSize
+            }
     
-            HTTP.SendHTTP(req, res, 200, {files})
+            HTTP.SendHTTP(req, res, 200, {files, storageBytesUsed})
         }).catch(error => {
             console.error('An error occurred while getting all Files with userId:', req.cookies.auth, '. The error was:', error)
             HTTP.SendHTTP(req, res, 500, String(error) || 'An unknown error occurred.');

--- a/public/index.css
+++ b/public/index.css
@@ -83,9 +83,12 @@ nav {
     border-bottom: 2px solid black;
     width: 100%;
     display: flex;
-    justify-content: space-between;
     align-items: center;
     background-color: white;
+}
+
+nav > * {
+    flex: 1
 }
 
 main {
@@ -94,8 +97,13 @@ main {
 
 #add-file-button {
     font-size: 30pt;
-    margin-right: 10px;
     font-family: "AntDesign";
+    text-align: right;
+    margin-right: 10px;
+}
+
+#storage-usage-header {
+    text-align: center;
 }
 
 #files-list {

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
 
         <nav>
             <h1>File Storage</h1>
+            <h1 id="storage-usage-header">Storage Used: <span id="storage-usage">Loading...</span></h1>
             <label for="file-upload" id="add-file-button">&#xE627</label>
         </nav>
         <main>

--- a/public/index.js
+++ b/public/index.js
@@ -315,6 +315,8 @@ function getFiles() {
         if (data.files.length === 0) {
             const container = createBeforeFilesContainer();
 
+            document.getElementById('storage-usage').textContent = 'None'
+
             const text = document.createElement('h1');
             text.textContent = 'No files. Press the + button to upload something!'
             container.appendChild(text);
@@ -324,6 +326,8 @@ function getFiles() {
         document.getElementById('before-files-container')?.remove();
 
         removeChildrenFromElement(document.getElementById('files-list'));
+
+        document.getElementById('storage-usage').textContent = SizeCalculator(data.storageBytesUsed);
 
         for (const file of data.files) {
             createFile(file)


### PR DESCRIPTION
The GET /files API should return the total number of bytes stored in Discord.
The frontend will then show the storage usage at the top of the page.