### PR TITLE
Upload partial read Buffer chunks to Discord instead of split up chunk files

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,0 +1,1 @@
+export const FileChunkSize = 9 * 1024 * 1024 //9MB - Discord limit is 10MB, so having each file 1MB less than the limit ensures the limit is never reached

--- a/controllers/UserController.ts
+++ b/controllers/UserController.ts
@@ -63,11 +63,9 @@ userController.post('/file', upload.single('file'), (req, res) => {
 
         console.log('Initiating file upload...')
 
-        const filename = req.file.filename;
-
         const chunkCount = Math.ceil(req.file.size / FileChunkSize)
 
-        const uploader = new Uploader(filename, chunkCount, req, res, req.cookies.auth, req.file.originalname, req.file.size, req.body.fileId)
+        const uploader = new Uploader(req.file.path, chunkCount, req, res, req.cookies.auth, req.file.originalname, req.file.size, req.body.fileId)
 
         for (let i = 0; i < chunkCount; i++) {
             uploader.uploadChunk(i)

--- a/controllers/UserController.ts
+++ b/controllers/UserController.ts
@@ -64,15 +64,10 @@ userController.post('/file', upload.single('file'), (req, res) => {
         console.log('Initiating file upload...')
 
         const filename = req.file.filename;
-        const filenameWithoutExt = filename.slice(0, filename.indexOf('.'));
-
-        const folderPath = `/temp/${filenameWithoutExt}-enc`
-
-        fs.mkdirSync(folderPath);
 
         const chunkCount = Math.ceil(req.file.size / FileChunkSize)
 
-        const uploader = new Uploader(folderPath, chunkCount, req, res, req.cookies.auth, req.file.originalname, req.file.size, req.body.fileId)
+        const uploader = new Uploader(filename, chunkCount, req, res, req.cookies.auth, req.file.originalname, req.file.size, req.body.fileId)
 
         for (let i = 0; i < chunkCount; i++) {
             uploader.uploadChunk(i)

--- a/libraries/Uploader.ts
+++ b/libraries/Uploader.ts
@@ -102,7 +102,7 @@ export default class Uploader {
             }
 
             if (event.event === 'MESSAGE_SENT') {                
-                this.#messageIds[event.chunkNumber - 1] = event.messageId
+                this.#messageIds[event.chunkNumber] = event.messageId
                 this.#handleFinishUpload()
                 const worker = this.#uploadWorkers[workerIndex]
                 if (this.#chunksUploaded < this.#chunksToUpload && this.#promiseQueue.length > 0) {

--- a/workers/UploadWorker.ts
+++ b/workers/UploadWorker.ts
@@ -54,7 +54,6 @@ const hashedEncryptionKey = crypto.createHash('sha512').update(process.env.encry
 
 function encryptBuffer(buffer: Buffer): Buffer {
     const iv = crypto.randomBytes(16);
-    console.log('iv:', iv)
     const cipher = crypto.createCipheriv(process.env.encryptionAlgorithm, hashedEncryptionKey, iv);
     return Buffer.concat([iv, cipher.update(buffer), cipher.final()])
 }

--- a/workers/UploadWorker.ts
+++ b/workers/UploadWorker.ts
@@ -1,7 +1,10 @@
 import { Client, TextChannel } from "discord.js";
 import { parentPort, workerData } from "worker_threads";
+import fs from 'fs';
+import crypto from 'crypto';
+import { FileChunkSize } from "../constants";
 
-let {folderPath}: {folderPath: string} = workerData;
+let {filePath}: {filePath: string} = workerData;
 
 let client: Client<true>
 let channel: TextChannel
@@ -28,12 +31,54 @@ async function getReady(): Promise<void> {
 
 getReady();
 
+function partialReadFile(start: number, end: number): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const stream = fs.createReadStream(filePath, {start, end})
+        const buffers = [];
+
+        stream.on('data', (chunk) => {
+            buffers.push(chunk)
+        })
+
+        stream.on('error', (err) => {
+            reject(err)
+        })
+
+        stream.on('end', () => {
+            resolve(Buffer.concat(buffers))
+        })
+    })
+}
+
+const hashedEncryptionKey = crypto.createHash('sha512').update(process.env.encryptionKey).digest('base64').slice(0, 32);
+
+function encryptBuffer(buffer: Buffer): Buffer {
+    const iv = crypto.randomBytes(16);
+    console.log('iv:', iv)
+    const cipher = crypto.createCipheriv(process.env.encryptionAlgorithm, hashedEncryptionKey, iv);
+    return Buffer.concat([iv, cipher.update(buffer), cipher.final()])
+}
+
 parentPort.on('message', async (chunkNumber: number) => {
     let event: UploadWorkerEvent
+
+    const startReadPosition = chunkNumber * FileChunkSize + (chunkNumber === 0 ? 0 : 1)
+    const endReadPosition = (chunkNumber + 1) * FileChunkSize
+
+    let fileBuffer: Buffer
+
+    try {
+        fileBuffer = await partialReadFile(startReadPosition, endReadPosition)
+    } catch (e) {
+        console.error('An error occurred while reading chunk number', chunkNumber, 'on file:', filePath, '. The error was:', e)   
+    }
+
+    const encryptedBuffer = encryptBuffer(fileBuffer)
+
     try {
         const message = await channel.send({
             files: [{
-                attachment: `${folderPath}/${chunkNumber}`,
+                attachment: encryptedBuffer,
                 name: `file`,
                 description: 'A cool file'
             }]


### PR DESCRIPTION
Reasoning behind this is in #49. This PR halves the required local server drive reads and writes by reading chunks of the file at offsets and upload those in-memory chunks of the file to Discord. Previously what happened was the uploaded file was read sequentially, new chunk files no bigger than the chunk size were created from the original file, and then each chunk file was uploaded to Discord.

Previously the uploaded file was effectively written to the disk twice. With this PR, the uploaded file is only written to the disk once.

This majorly improves performance on HDDs and halves write wear on SSDs.