### PR TITLE
Make Downloader use the raw Discord API instead of Discord.js

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,1 +1,4 @@
 export const FileChunkSize = 9 * 1024 * 1024 //9MB - Discord limit is 10MB, so having each file 1MB less than the limit ensures the limit is never reached
+export const authHeaders = {
+    'Authorization': `Bot ${process.env.discordBotToken}`
+}

--- a/libraries/Deleter.ts
+++ b/libraries/Deleter.ts
@@ -1,10 +1,7 @@
 import { startFileAction, setFileActionText, removeFileAction } from "../socketHandler";
 import mongoose from "mongoose";
 import axios from "axios";
-
-const authHeaders = {
-    'Authorization': `Bot ${process.env.discordBotToken}`
-}
+import { authHeaders } from "../constants";
 
 function promiseFactory(messageId: string): Promise<void> {
     return new Promise((resolve, reject) => {

--- a/workers/UploadWorker.ts
+++ b/workers/UploadWorker.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "worker_threads";
 import fs from 'fs';
 import crypto from 'crypto';
-import { FileChunkSize } from "../constants";
+import { authHeaders, FileChunkSize } from "../constants";
 import axios from "axios";
 
 let {filePath}: {filePath: string} = workerData;
@@ -31,10 +31,6 @@ function encryptBuffer(buffer: Buffer): Buffer {
     const iv = crypto.randomBytes(16);
     const cipher = crypto.createCipheriv(process.env.encryptionAlgorithm, hashedEncryptionKey, iv);
     return Buffer.concat([iv, cipher.update(buffer), cipher.final()])
-}
-
-const authHeaders = {
-    'Authorization': `Bot ${process.env.discordBotToken}`
 }
 
 parentPort.on('message', async (chunkNumber: number) => {


### PR DESCRIPTION
This pull request, while making Downloader use the raw Discord API instead of Discord.js, also adds error handling to Downloader. It can now retry any errors that occur, and is a lot safer with concurrency.